### PR TITLE
Install javascript dependencies in bin/setup script

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -19,7 +19,7 @@ chdir APP_ROOT do
   system('bundle check') || system!('bundle install')
 
   # Install JavaScript dependencies if using Yarn
-  # system('bin/yarn')
+  system('bin/yarn')
 
 
   # puts "\n== Copying sample files =="


### PR DESCRIPTION
This allows easy dev environment setup by running `bin/setup`.