### PR TITLE
Pluralize students mentored in profile page correctly

### DIFF
--- a/app/views/profiles/show.html.haml
+++ b/app/views/profiles/show.html.haml
@@ -35,7 +35,7 @@
               %i.fa.fa-fw.fa-handshake-o
               Helped
               .count #{@helped_count}
-              students
+              = "student".pluralize(@helped_count)
           .hr
           %h3 Elsewhere on the web
 


### PR DESCRIPTION
## Before
<img width="274" alt="screen shot 2017-08-18 at 1 03 42 am" src="https://user-images.githubusercontent.com/1901520/29425844-489373be-83b7-11e7-8549-b8f8f1d79334.png">

## After
<img width="278" alt="screen shot 2017-08-18 at 1 45 26 am" src="https://user-images.githubusercontent.com/1901520/29425843-487c752e-83b7-11e7-9ba5-cf70dc11ecd7.png">
