### PR TITLE
Fix typo in unapproved completion confirmation modal

### DIFF
--- a/app/views/my/solutions/confirm_unapproved_completion.html.haml
+++ b/app/views/my/solutions/confirm_unapproved_completion.html.haml
@@ -13,7 +13,7 @@
     %li you'll no longer get mentor feedback on this exercise
     %li you won't unlock #{@solution.exercise.title}'s side quests
     %li you'll not recieve a laptop sticker once you've finished the Track
-    %li you will be able to reactive the exercise in the future
+    %li you will be able to reactivate the exercise in the future
 
   =form_tag [:complete, :my, @solution], method: :patch, remote: true do
     =check_box_tag :agree, 1, false, required: true


### PR DESCRIPTION
## Before
<img width="491" alt="screen_shot_2017-08-18_at_1_05_53_am" src="https://user-images.githubusercontent.com/1901520/29426037-ee63311c-83b7-11e7-8257-dc3e0349d1f5.png">

## After
<img width="496" alt="screen_shot_2017-08-18_at_1_51_06_am" src="https://user-images.githubusercontent.com/1901520/29426038-ee8e040a-83b7-11e7-8b53-4e341dca5a4a.png">

