### PR TITLE
Fix notifications page breadcrumbs for site consistency

### DIFF
--- a/app/views/my/notifications/index.html.haml
+++ b/app/views/my/notifications/index.html.haml
@@ -1,7 +1,7 @@
 #notifications-page
   #nav.lo-nav-bar
     .lo-container
-      =link_to "Language Files", :tracks
+      =link_to "Language Tracks", :tracks
       =image_tag "nav-divider.png"
       %span Notifications
 


### PR DESCRIPTION
## Before
<img width="1119" alt="screen_shot_2017-08-18_at_2_16_54_am" src="https://user-images.githubusercontent.com/1901520/29427188-b4afbfae-83bb-11e7-9e47-d37b3632abca.png">

## After
<img width="1130" alt="screen_shot_2017-08-18_at_2_17_09_am" src="https://user-images.githubusercontent.com/1901520/29427187-b4ac4dec-83bb-11e7-95f6-a8129d4f2c75.png">

