### PR TITLE
Avoid double render error in api solutions controller

### DIFF
--- a/app/controllers/api/solutions_controller.rb
+++ b/app/controllers/api/solutions_controller.rb
@@ -104,7 +104,7 @@ class API::SolutionsController < APIController
 
     params[:files].each do |file|
       if file.size.to_f > NUM_BYTES_IN_MEGABYTE
-        render_error(400, :file_too_large, "#{file.original_filename} is too large")
+        return render_error(400, :file_too_large, "#{file.original_filename} is too large")
       end
     end
 


### PR DESCRIPTION
This fixes the following bugsnag:

https://app.bugsnag.com/exercism/exercism-v2/errors/5af0fc6992518b0019335176?event_id=5af0fc6992518b0019335175&i=em&m=nw