### PR TITLE
Read interactive walkthrough from new location

### DIFF
--- a/app/controllers/my/solutions_controller.rb
+++ b/app/controllers/my/solutions_controller.rb
@@ -29,7 +29,7 @@ class My::SolutionsController < MyController
   end
 
   def walkthrough
-    @walkthrough = Git::WebsiteContent.head.walkthrough['compiled.html']
+    @walkthrough = Git::WebsiteContent.head.walkthrough['index.html']
     render_modal("solution-walkthrough", "walkthrough")
   end
 


### PR DESCRIPTION
Per decision documented in https://github.com/exercism/reboot/issues/248

I went with `walkthrough/index.html` rather than `walkthrough.html` because (a) it feels a bit cleaner, and (b) we already have beautiful abstractions for reading from a folder, and I'm not sure if a folder reader would work with `.`.