### PR TITLE
Unlock solutions that are not analyzed

### DIFF
--- a/app/services/analysis_services/process_analysis.rb
+++ b/app/services/analysis_services/process_analysis.rb
@@ -9,6 +9,13 @@ module AnalysisServices
     end
 
     def call
+      # If we don't have an analyser, then we should just
+      # undo what we've done so far and leave this alone.
+      if analysis_status == :no_analyzer
+        remove_system_lock
+        return
+      end
+
       create_database_record
       handle_analysis
       remove_system_lock
@@ -46,7 +53,7 @@ module AnalysisServices
     end
 
     def remove_system_lock
-      solution.solution_locks.where(user_id: User::SYSTEM_USER_ID).destroy_all
+      UnlockSolution.(solution)
     end
 
     def analysis_succeeded?

--- a/app/services/analysis_services/unlock_solution.rb
+++ b/app/services/analysis_services/unlock_solution.rb
@@ -1,0 +1,11 @@
+module AnalysisServices
+  class UnlockSolution
+    include Mandate
+
+    initialize_with(:solution)
+
+    def call
+      solution.solution_locks.where(user_id: User::SYSTEM_USER_ID).destroy_all
+    end
+  end
+end

--- a/test/services/analysis_services/process_analysis_test.rb
+++ b/test/services/analysis_services/process_analysis_test.rb
@@ -7,6 +7,22 @@ module AnalysisServices
     APPROVAL_WITH_COMMENT_DATA = {'status' => "approve_with_comment"}.freeze
     APPROVAL_DATA = { 'status' => "approve" }.freeze
 
+    test "removes locks and aborts if no analyzer" do
+      solution = create :solution
+      iteration = create :iteration, solution: solution
+
+      system_lock = create :solution_lock, solution: solution, user: create(:user, :system)
+      mentor_lock = create :solution_lock, solution: solution
+      ProcessAnalysis.(iteration, 'no_analyzer', nil)
+
+      assert_raises ActiveRecord::RecordNotFound do
+        system_lock.reload
+      end
+
+      assert mentor_lock.reload
+      refute iteration.analyses.any?
+    end
+
     test "removes any locks" do
       solution = create :solution
       iteration = create :iteration, solution: solution

--- a/test/services/analysis_services/unlock_solution_test.rb
+++ b/test/services/analysis_services/unlock_solution_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+module AnalysisServices
+  class UnlockSolutionTest < ActiveSupport::TestCase
+
+    test "removes any locks" do
+      solution = create :solution
+      iteration = create :iteration, solution: solution
+
+      system_lock = create :solution_lock, solution: solution, user: create(:user, :system)
+      mentor_lock = create :solution_lock, solution: solution
+      UnlockSolution.(solution)
+
+      assert_raises ActiveRecord::RecordNotFound do
+        system_lock.reload
+      end
+
+      assert mentor_lock.reload
+    end
+  end
+end


### PR DESCRIPTION
At the moment, if there's not an analyzer we never receive a message from the orchestrator and the solution doesn't get unlocked until it times out, which is bad. This listens for a new message from the orchestrator informing of a missing analyzer and unlocks the solution once it receives it.

Goes with https://github.com/exercism/analyzer-orchestrator/pull/24